### PR TITLE
Update settings removal in all of my modules (+ a small tweak)

### DIFF
--- a/modules/quick-actions/relaunch.js
+++ b/modules/quick-actions/relaunch.js
@@ -35,13 +35,7 @@ let obj = {
   },
 
   remove: async () => {
-    let settingItem = goosemodScope.settings.items.find(
-      (x) => x[1] === "Relaunch"
-    );
-    goosemodScope.settings.items.splice(
-      goosemodScope.settings.items.indexOf(settingItem),
-      1
-    );
+    goosemod.settings.removeItem("Relaunch");
     document.removeEventListener("keydown", keydownHandler);
   },
 

--- a/modules/quick-actions/relaunch.js
+++ b/modules/quick-actions/relaunch.js
@@ -1,4 +1,4 @@
-let version = "1.1.0";
+let version = "1.2.0";
 
 const openModal = async () => {
   if (

--- a/modules/themes/comfyTheme.js
+++ b/modules/themes/comfyTheme.js
@@ -1,4 +1,4 @@
-const version = "1.0.0";
+const version = "1.1.0";
 
 let settings = {
   statusIcon: false,
@@ -305,12 +305,7 @@ let obj = {
     ]),
 
   remove: async () => {
-    goosemod.settings.items.splice(
-      goosemod.settings.items.indexOf(
-        goosemod.settings.items.find((x) => x[1] === "Comfy Theme")
-      ),
-      1
-    );
+    goosemod.settings.removeItem("Comfy Theme");
     style.remove();
     try {
       cssStatusIcon.remove();

--- a/modules/ui/fullscreenInbox.js
+++ b/modules/ui/fullscreenInbox.js
@@ -1,4 +1,4 @@
-const version = "1.0.0";
+const version = "1.1.0";
 
 let settings = {
   floating: true,
@@ -82,12 +82,7 @@ let obj = {
     ]),
 
   remove: async () => {
-    goosemod.settings.items.splice(
-      goosemod.settings.items.indexOf(
-        goosemod.settings.items.find((x) => x[1] === "Fullscreen Inbox")
-      ),
-      1
-    );
+    goosemod.settings.removeItem("Fullscreen Inbox");
     style.remove();
   },
 

--- a/modules/ui/toggleMessageButtons.js
+++ b/modules/ui/toggleMessageButtons.js
@@ -1,4 +1,4 @@
-const version = "1.0.0";
+const version = "1.1.0";
 
 let settings = {
   buttonsToggled: true,
@@ -12,9 +12,9 @@ let style;
 
 const updateContextItem = async (val) => {
   try {
-    await goosemodScope.patcher.contextMenu.remove("toggle-message-buttons");
+    await goosemod.patcher.contextMenu.remove("toggle-message-buttons");
 
-    goosemodScope.patcher.contextMenu.add("textarea-context", {
+    goosemod.patcher.contextMenu.add("textarea-context", {
       id: "toggle-message-buttons",
       label: `${val ? "Disable" : "Enable"} Buttons`,
       action: () => {
@@ -42,7 +42,7 @@ let obj = {
   },
 
   remove: async () => {
-    goosemodScope.patcher.contextMenu.remove("toggle-message-buttons");
+    goosemod.patcher.contextMenu.remove("toggle-message-buttons");
     document.body.classList.remove('gm-toggle-messages-buttons');
     
     style.remove();


### PR DESCRIPTION
Updated all my modules to use the new `goosemod.settings.removeItem()` method.
The small tweak: I replaced all references to `goosemodScope` in Toggle Message Buttons with `goosemod`.